### PR TITLE
Feat: 카카오 로그인 기본 구현 (#4)

### DIFF
--- a/gguro.xcodeproj/project.pbxproj
+++ b/gguro.xcodeproj/project.pbxproj
@@ -6,6 +6,12 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		238564302E110EC2008F25B1 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 2385642F2E110EC2008F25B1 /* KakaoSDKAuth */; };
+		238564322E110EC2008F25B1 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 238564312E110EC2008F25B1 /* KakaoSDKCommon */; };
+		238564342E110EC2008F25B1 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 238564332E110EC2008F25B1 /* KakaoSDKUser */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		23855B182DDE163F008F25B1 /* gguro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = gguro.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -38,6 +44,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				238564322E110EC2008F25B1 /* KakaoSDKCommon in Frameworks */,
+				238564302E110EC2008F25B1 /* KakaoSDKAuth in Frameworks */,
+				238564342E110EC2008F25B1 /* KakaoSDKUser in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,6 +89,9 @@
 			);
 			name = gguro;
 			packageProductDependencies = (
+				2385642F2E110EC2008F25B1 /* KakaoSDKAuth */,
+				238564312E110EC2008F25B1 /* KakaoSDKCommon */,
+				238564332E110EC2008F25B1 /* KakaoSDKUser */,
 			);
 			productName = gguro;
 			productReference = 23855B182DDE163F008F25B1 /* gguro.app */;
@@ -109,6 +121,9 @@
 			);
 			mainGroup = 23855B0F2DDE163F008F25B1;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				2385642E2E110EC2008F25B1 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 23855B192DDE163F008F25B1 /* Products */;
 			projectDirPath = "";
@@ -281,7 +296,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = umc.gguro;
+				PRODUCT_BUNDLE_IDENTIFIER = ae.gguro.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -311,7 +326,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = umc.gguro;
+				PRODUCT_BUNDLE_IDENTIFIER = ae.gguro.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -341,6 +356,35 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		2385642E2E110EC2008F25B1 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.24.4;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2385642F2E110EC2008F25B1 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2385642E2E110EC2008F25B1 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		238564312E110EC2008F25B1 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2385642E2E110EC2008F25B1 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		238564332E110EC2008F25B1 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2385642E2E110EC2008F25B1 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 23855B102DDE163F008F25B1 /* Project object */;
 }

--- a/gguro/Info.plist
+++ b/gguro/Info.plist
@@ -2,6 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakaoeebb1242e2da80fe103994d0366c0671</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>NanumSquareRoundOTFB.otf</string>

--- a/gguro/Views/Custom/Button/KakaoLoginButton.swift
+++ b/gguro/Views/Custom/Button/KakaoLoginButton.swift
@@ -1,0 +1,48 @@
+//
+//  KakaoLoginButton.swift
+//  gguro
+//
+//  Created by 김미주 on 6/29/25.
+//
+
+import SwiftUI
+import KakaoSDKCommon
+import KakaoSDKAuth
+import KakaoSDKUser
+
+struct KakaoLoginButton: View {
+    var body: some View {
+        Button(action: {
+            if (UserApi.isKakaoTalkLoginAvailable()) {
+                UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                    if let error = error {
+                        print("카카오 로그인 오류: \(error)")
+                    }
+                    if let oauthToken = oauthToken {
+                        print("카카오 로그인 성공: \(oauthToken)")
+                        // 카카오 로그인
+                    }
+                }
+            } else {
+                UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
+                    if let error = error {
+                        print("카카오 로그인 오류: \(error)")
+                    }
+                    if let oauthToken = oauthToken {
+                        print("카카오 로그인 성공: \(oauthToken)")
+                        // 카카오 로그인
+                    }
+                }
+            }
+        }) {
+            Image(.iconLoginKakao)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 90, height: 90)
+        }
+    }
+}
+
+#Preview {
+    KakaoLoginButton()
+}

--- a/gguro/Views/Onboarding/LoginView.swift
+++ b/gguro/Views/Onboarding/LoginView.swift
@@ -13,10 +13,7 @@ struct LoginView: View {
             BackgroundImage()
             
             VStack {
-                Text("Pretendard 프리텐다드")
-                    .font(.PretendardSemiBold32)
-                Text("NanumSquareRound 나눔스퀘어라운드")
-                    .font(.NanumExtraBold32)
+                KakaoLoginButton()
             }
         }
     }

--- a/gguro/gguroApp.swift
+++ b/gguro/gguroApp.swift
@@ -6,12 +6,23 @@
 //
 
 import SwiftUI
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 struct gguroApp: App {
+    init() {
+        KakaoSDK.initSDK(appKey: "eebb1242e2da80fe103994d0366c0671")
+    }
+    
     var body: some Scene {
         WindowGroup {
             LoginView()
+                .onOpenURL { url in
+                    if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                        _ = AuthController.handleOpenUrl(url: url)
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 iOS SDK를 연동하여 카카오 계정으로 로그인할 수 있는 기능이 추가되었습니다.
  * 카카오 로그인 버튼이 로그인 화면에 추가되었습니다.
  * 앱 실행 시 카카오 SDK가 초기화되며, 카카오톡 또는 카카오 계정으로 로그인 시도를 지원합니다.

* **설정 변경**
  * 앱 번들 식별자가 변경되었습니다.
  * 카카오 로그인 연동을 위한 URL 스킴 및 쿼리 스킴이 Info.plist에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->